### PR TITLE
Fix stray prompt in style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -494,4 +494,3 @@ section:not(.hero-banner) {
     color: white;
   }
   
-  


### PR DESCRIPTION
## Summary
- remove leftover terminal prompt from the end of `style.css`

## Testing
- `tail -n 5 style.css`


------
https://chatgpt.com/codex/tasks/task_e_68488ee7fc0c832fa3b0269deb77d388