### PR TITLE
Fix title tag in math page

### DIFF
--- a/kakomonsuugaku.html
+++ b/kakomonsuugaku.html
@@ -3,8 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><h1 style="color: white;">苦手でも大丈夫！やさしく学べる数学過去問解説</h1>
-  </title>
+  <title>苦手でも大丈夫！やさしく学べる数学過去問解説</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
   <!-- 分数表示用スタイル -->


### PR DESCRIPTION
## Summary
- remove `<h1>` tag embedded inside `<title>` in `kakomonsuugaku.html`

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68488ee46bf8832fbd45e03b20de3eda